### PR TITLE
List displays to work with commands

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -262,13 +262,14 @@ When this command is executed, Scooby's Doo which is Bradly Cooper's pet's appoi
 
 === Editing a client or vet technician's details : `edit`
 
-Command format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]...`
+Command format: `edit INDEX [r/ROLE] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]...`
 
 The `edit` command amends the details of an existing client or vet technician, depending on which list the vet is currently viewing.
 The details of the specified person's index will be replaced with the supplied parameters from the user.
 The existing details will be overriden. The command expects these parameters: +
 [horizontal]
 *INDEX*:: The index of the person that the user wants to edit. It must be supplied by the user.
+*ROLE*:: The new role of the person that the user wants. It need not be supplied by the user.
 *NAME*:: The new name of the person that the user wants. It need not be supplied by the user.
 *PHONE*:: The new phone number of the person that the user wants. It need not be supplied by the user.
 *EMAIL*:: The new email of the person that the user wants. It need not be supplied by the user.

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -349,14 +349,14 @@ The user used the keyword Garf to find all pets containing the word Garf.
 The keyword is case insensitive. This means typing, "GARF", "garf" or "GaRf" will result in the same output.
 
 
-=== Selecting a client or vet technician: `select`
+=== Selecting a client, pet or vet technician: `select`
 
 Command format: `select INDEX` +
 
-The `select` command selects the client or vet technician identified by the index number on the currently viewed list. The command expects this parameter: +
+The `select` command selects the client, pet or vet technician identified by the index number on the currently viewed list. The command expects this parameter: +
 
 [horizontal]
-*INDEX*:: The index of the client or vet technician that the user wants to select. It must be supplied by the user.
+*INDEX*:: The index of the client, pet or vet technician that the user wants to select. It must be supplied by the user.
 
 Here is an example on using the command: +
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -166,14 +166,14 @@ Command format: `list vettech` +
 The `list vettech` command will display all vet technicians that are stored in the program.
 It automatically switches to the vet technician tab so that you can view them at a glance.
 
-=== Listing all appointments: `list appt`
+=== Listing all appointments: `list appt` `coming v2.0`
 
 Command format: `list appt` +
 
 The `list appt` command will display all appointments that are pending for the user.
 The list sorts upcoming appointments by date and then by time.
 
-=== Listing all information: `listall`
+=== Listing all information: `listall` `coming v2.0`
 
 Command format: `listall INDEX` +
 
@@ -200,27 +200,26 @@ Command format: `sortc` +
 
 The `sortc` command will sort all existing clients in the program in most recently added. This is the default ordering that is displayed in the program. +
 
-=== Removing a client: `delete`
+=== Removing a client or vet technician: `delete`
 
 Command format: `delete INDEX` +
 
-The `delete` command will remove a client from the program. Executing this command will remove all the pets associated to the client. +
-The command expects this parameter when called: +
+The `delete` command will remove a client from the program if the vet is viewing the client list. Executing this command will remove all the pets associated to the client. +
+The `delete` command will remove a vet technician from the program if the vet is viewing the vet technician list. The command expects this parameter when called: +
 
 [horizontal]
-*INDEX*:: The client's index in the program. This must be supplied by the user.
+*INDEX*:: The client or vet technician's index on the list displayed in the program. This must be supplied by the user.
 
 Here is an example of using the command `delete`: +
 
 * `delete 1` +
-Suppose there is only one person in the program called Alice Peterson and she has Garfield and Scooby Doo as her associated pets. This command will remove Alice, Garfield and Scooby Doo from the program.
+Suppose the vet is currently viewing the 'client' list and there is only one client in the program called Alice Peterson and she has Garfield and Scooby Doo as her associated pets. This command will remove Alice, Garfield and Scooby Doo from the program.
 
 === Removing a pet: `deletep`
 
 Command format: `deletep INDEX` +
 
-The `deletep` command will remove a pet from the program. Executing this command will remove the pet from the program. +
-The command expects this parameter when called: +
+The `deletep` command will remove a pet from the program. Executing this command will remove the pet from the program. The command expects this parameter when called: +
 
 [horizontal]
 *INDEX*:: The client's index in the program. This must be supplied by the user.
@@ -261,14 +260,15 @@ Here is an exammple of using the command `rmapptfrom`: +
 When this command is executed, Scooby's Doo which is Bradly Cooper's pet's appointment will be removed.
 
 
-=== Editing a client or vet tech's details : `edit`
+=== Editing a client or vet technician's details : `edit`
 
-Command format: `edit INDEX [n/ROLE] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]...`
+Command format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]...`
 
-The `edit` command amends the detail of an existing person. The details of the specified person's index will be replaced with the supplied parameters from the user. The existing details will be override. The command expects these parameters: +
+The `edit` command amends the details of an existing client or vet technician, depending on which list the vet is currently viewing.
+The details of the specified person's index will be replaced with the supplied parameters from the user.
+The existing details will be overriden. The command expects these parameters: +
 [horizontal]
 *INDEX*:: The index of the person that the user wants to edit. It must be supplied by the user.
-*ROLE*:: The new role of the person that the user wants. It need not be supplied by the user.
 *NAME*:: The new name of the person that the user wants. It need not be supplied by the user.
 *PHONE*:: The new phone number of the person that the user wants. It need not be supplied by the user.
 *EMAIL*:: The new email of the person that the user wants. It need not be supplied by the user.
@@ -277,10 +277,10 @@ The `edit` command amends the detail of an existing person. The details of the s
 
 The `edit` command is very similar to the `add` command. Here are some examples on using the command: +
 
-* `edit 1 n/VetTechnician e/newemail@email.com a/Blk 123, Clementi Ave 3 t/friend t/part_timer` +
-Here the user chooses to amend person 1 and changed the person's role, email, address and tags.
-* `edit 1 n/Client` +
-Here the user chooses to only change the role of the person specified at index 1 and omits the remaining parameters.
+* `edit 1 e/newemail@email.com a/Blk 123, Clementi Ave 3 t/friend t/part_timer` +
+Here the user chooses to amend person 1 on the currently viewed list and changes the person's email, address and tags.
+* `edit 1 n/Mary Tan` +
+Here the user chooses to only change the name of the person specified at index 1 on the currently viewed list and omits the remaining parameters.
 
 === Editing a pet's details: `editp` `coming v2.0`
 
@@ -349,18 +349,20 @@ The user used the keyword Garf to find all pets containing the word Garf.
 The keyword is case insensitive. This means typing, "GARF", "garf" or "GaRf" will result in the same output.
 
 
-=== Selecting a client : `select`
+=== Selecting a client or vet technician: `select`
 
 Command format: `select INDEX` +
 
-The `select` command selects the client identified by the index number. The command expects this parameter: +
+The `select` command selects the client or vet technician identified by the index number on the currently viewed list. The command expects this parameter: +
 
 [horizontal]
-*INDEX*:: The index of the client that the user wants to amend. It must be supplied by the user.
+*INDEX*:: The index of the client or vet technician that the user wants to select. It must be supplied by the user.
 
 Here is an example on using the command: +
 
-* `select 1`
+* `select 3` +
+The user is currently viewing the client list and wishes to select the 3rd client on the list.
+The program will scroll to and select the 3rd client on the list.
 
 === Scheduling an appointment : `schedule`
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,5 +9,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_PETS_LISTED_OVERVIEW = "%1$d pets listed!";
 
 }

--- a/src/main/java/seedu/address/commons/events/ui/ChangeListTabEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/ChangeListTabEvent.java
@@ -7,10 +7,10 @@ import seedu.address.commons.events.BaseEvent;
  */
 public class ChangeListTabEvent extends BaseEvent {
 
-    public final int targetIndex;
+    public final int targetList;
 
-    public ChangeListTabEvent(int targetIndex) {
-        this.targetIndex = targetIndex;
+    public ChangeListTabEvent(int targetList) {
+        this.targetList = targetList;
     }
 
     @Override

--- a/src/main/java/seedu/address/commons/events/ui/ClientPanelSelectionChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/ClientPanelSelectionChangedEvent.java
@@ -1,0 +1,26 @@
+package seedu.address.commons.events.ui;
+
+import seedu.address.commons.events.BaseEvent;
+import seedu.address.ui.ClientCard;
+
+/**
+ * Represents a selection change in the Client List Panel
+ */
+public class ClientPanelSelectionChangedEvent extends BaseEvent {
+
+
+    private final ClientCard newSelection;
+
+    public ClientPanelSelectionChangedEvent(ClientCard newSelection) {
+        this.newSelection = newSelection;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+
+    public ClientCard getNewSelection() {
+        return newSelection;
+    }
+}

--- a/src/main/java/seedu/address/commons/events/ui/JumpToListRequestEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/JumpToListRequestEvent.java
@@ -9,9 +9,11 @@ import seedu.address.commons.events.BaseEvent;
 public class JumpToListRequestEvent extends BaseEvent {
 
     public final int targetIndex;
+    public final int targetList;
 
-    public JumpToListRequestEvent(Index targetIndex) {
+    public JumpToListRequestEvent(Index targetIndex, int targetList) {
         this.targetIndex = targetIndex.getZeroBased();
+        this.targetList = targetList;
     }
 
     @Override

--- a/src/main/java/seedu/address/commons/events/ui/VetTechnicianPanelSelectionChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/VetTechnicianPanelSelectionChangedEvent.java
@@ -1,0 +1,26 @@
+package seedu.address.commons.events.ui;
+
+import seedu.address.commons.events.BaseEvent;
+import seedu.address.ui.VetTechnicianCard;
+
+/**
+ * Represents a selection change in the VetTechnician List Panel
+ */
+public class VetTechnicianPanelSelectionChangedEvent extends BaseEvent {
+
+
+    private final VetTechnicianCard newSelection;
+
+    public VetTechnicianPanelSelectionChangedEvent(VetTechnicianCard newSelection) {
+        this.newSelection = newSelection;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+
+    public VetTechnicianCard getNewSelection() {
+        return newSelection;
+    }
+}

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -36,4 +36,12 @@ public interface Logic {
 
     /** Returns the list of input entered by the user, encapsulated in a {@code ListElementPointer} object */
     ListElementPointer getHistorySnapshot();
+
+    /**
+     * Sets the index of the current list that is viewed
+     */
+    void setCurrentList(int currList);
+
+    /** Get the index of the current list that is viewed */
+    int getCurrentList();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -26,6 +26,7 @@ public class LogicManager extends ComponentManager implements Logic {
     private final CommandHistory history;
     private final AddressBookParser addressBookParser;
     private final UndoRedoStack undoRedoStack;
+    private int currList = 0;
 
     public LogicManager(Model model) {
         this.model = model;
@@ -71,5 +72,16 @@ public class LogicManager extends ComponentManager implements Logic {
     @Override
     public ListElementPointer getHistorySnapshot() {
         return new ListElementPointer(history.getHistory());
+    }
+
+    @Override
+    public void setCurrentList(int currList) {
+        this.currList = currList;
+        model.setCurrentList(currList);
+    }
+
+    @Override
+    public int getCurrentList() {
+        return this.currList;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -7,6 +7,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TECHNICIAN;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Person;
@@ -54,6 +57,9 @@ public class AddCommand extends UndoableCommand {
         requireNonNull(model);
         try {
             model.addPerson(toAdd);
+            model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            model.updateFilteredVetTechnicianList(PREDICATE_SHOW_ALL_TECHNICIAN);
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
         } catch (DuplicatePersonException e) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -25,6 +25,16 @@ public abstract class Command {
     }
 
     /**
+     * Constructs a feedback message to summarise an operation that displayed a listing of pets.
+     *
+     * @param displaySize used to generate summary
+     * @return summary message for persons displayed
+     */
+    public static String getMessageForPetListShownSummary(int displaySize) {
+        return String.format(Messages.MESSAGE_PETS_LISTED_OVERVIEW, displaySize);
+    }
+
+    /**
      * Executes the command and returns the result message.
      *
      * @return feedback message of the operation result for display

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -28,12 +28,17 @@ public class DeleteCommand extends UndoableCommand {
 
     private final Index targetIndex;
 
+    private int currList = 0; //default is on client list upon opening app
+
     private Person personToDelete;
 
     public DeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
+    public void setCurrentList() {
+        this.currList = model.getCurrentList();
+    }
 
     @Override
     public CommandResult executeUndoableCommand() {
@@ -49,7 +54,17 @@ public class DeleteCommand extends UndoableCommand {
 
     @Override
     protected void preprocessUndoableCommand() throws CommandException {
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<? extends Person> lastShownList;
+
+        setCurrentList();
+
+        if (currList == 0) {
+            lastShownList = model.getFilteredClientList();
+        } else if (currList == 2) {
+            lastShownList = model.getFilteredVetTechnicianList();
+        } else {
+            throw new CommandException("Not currently on a list that 'delete' command can change");
+        }
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -42,6 +43,7 @@ public class EditCommand extends UndoableCommand {
             + "by the index number used in the last person listing. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_PERSON_ROLE + "ROLE] "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -7,7 +7,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TECHNICIAN;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -90,6 +92,9 @@ public class EditCommand extends UndoableCommand {
             throw new AssertionError("The target person cannot be missing");
         }
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
+        model.updateFilteredVetTechnicianList(PREDICATE_SHOW_ALL_TECHNICIAN);
+
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -100,7 +100,6 @@ public class EditCommand extends UndoableCommand {
         setCurrentList();
 
         if (currList == 0) {
-            System.out.println("test");
             lastShownList = model.getFilteredClientList();
         } else if (currList == 2) {
             lastShownList = model.getFilteredVetTechnicianList();

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -59,12 +59,13 @@ public class EditCommand extends UndoableCommand {
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
+    private int currList = 0; //default is on client list upon opening app
 
     private Person personToEdit;
     private Person editedPerson;
 
     /**
-     * @param index of the person in the filtered person list to edit
+     * @param index                of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
     public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
@@ -73,6 +74,10 @@ public class EditCommand extends UndoableCommand {
 
         this.index = index;
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
+    }
+
+    public void setCurrentList() {
+        this.currList = model.getCurrentList();
     }
 
     @Override
@@ -90,7 +95,18 @@ public class EditCommand extends UndoableCommand {
 
     @Override
     protected void preprocessUndoableCommand() throws CommandException {
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<? extends Person> lastShownList;
+
+        setCurrentList();
+
+        if (currList == 0) {
+            System.out.println("test");
+            lastShownList = model.getFilteredClientList();
+        } else if (currList == 2) {
+            lastShownList = model.getFilteredVetTechnicianList();
+        } else {
+            throw new CommandException("Not currently on a list that 'edit' command can change");
+        }
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -155,7 +171,8 @@ public class EditCommand extends UndoableCommand {
         private Address address;
         private Set<Tag> tags;
 
-        public EditPersonDescriptor() {}
+        public EditPersonDescriptor() {
+        }
 
         /**
          * Copy constructor.

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -43,7 +42,6 @@ public class EditCommand extends UndoableCommand {
             + "by the index number used in the last person listing. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_PERSON_ROLE + "ROLE] "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,6 +1,12 @@
 package seedu.address.logic.commands;
 
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.client.Client;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.pet.Pet;
+import seedu.address.model.vettechnician.VetTechnician;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -16,15 +22,50 @@ public class FindCommand extends Command {
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
     private final NameContainsKeywordsPredicate predicate;
+    private int currList = 0; //default is on client list upon opening app
 
     public FindCommand(NameContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 
+    public void setCurrentList() {
+        this.currList = model.getCurrentList();
+    }
+
     @Override
     public CommandResult execute() {
-        model.updateFilteredPersonList(predicate);
-        return new CommandResult(getMessageForPersonListShownSummary(model.getFilteredPersonList().size()));
+        setCurrentList();
+
+        if (currList == 0) {
+            model.updateFilteredClientList(new Predicate<Client>() {
+                @Override
+                public boolean test(Client client) {
+                    return predicate.getKeywords().stream().anyMatch(keyword ->
+                            StringUtil.containsWordIgnoreCase(client.getName().fullName, keyword));
+                }
+            });
+            return new CommandResult(getMessageForPersonListShownSummary(model.getFilteredClientList().size()));
+        } else if (currList == 1) {
+            model.updateFilteredPetList(new Predicate<Pet>() {
+                @Override
+                public boolean test(Pet pet) {
+                    return predicate.getKeywords().stream().anyMatch(keyword ->
+                            StringUtil.containsWordIgnoreCase(pet.getPetName().fullPetName, keyword));
+                }
+            });
+            return new CommandResult(getMessageForPetListShownSummary(model.getFilteredPetList().size()));
+        } else if (currList == 2) {
+            model.updateFilteredVetTechnicianList(new Predicate<VetTechnician>() {
+                @Override
+                public boolean test(VetTechnician vetTechnician) {
+                    return predicate.getKeywords().stream().anyMatch(keyword ->
+                            StringUtil.containsWordIgnoreCase(vetTechnician.getName().fullName, keyword));
+                }
+            });
+            return new CommandResult(getMessageForPersonListShownSummary(model.getFilteredVetTechnicianList().size()));
+        }
+
+        return new CommandResult(getMessageForPersonListShownSummary(0));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,7 +1,8 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PET;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TECHNICIAN;
 
 import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.Messages;
@@ -35,7 +36,7 @@ public class ListCommand extends Command {
 
         switch (targetType) {
         case "client":
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
             EventsCenter.getInstance().post(new ChangeListTabEvent(0));
             break;
 
@@ -45,7 +46,7 @@ public class ListCommand extends Command {
             break;
 
         case "vettech":
-            //model.updateFilteredVetTechList(PREDICATE_SHOW_ALL_VETTECH);
+            model.updateFilteredVetTechnicianList(PREDICATE_SHOW_ALL_TECHNICIAN);
             EventsCenter.getInstance().post(new ChangeListTabEvent(2));
             break;
 

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -7,7 +7,6 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.ui.JumpToListRequestEvent;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.person.Person;
 
 /**
  * Selects a person identified using it's last displayed index from the address book.
@@ -23,25 +22,44 @@ public class SelectCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_SELECT_PERSON_SUCCESS = "Selected Person: %1$s";
+    public static final String MESSAGE_SELECT_PET_SUCCESS = "Selected Pet: %1$s";
 
     private final Index targetIndex;
+    private int currList = 0; //default is on client list upon opening app
 
     public SelectCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
+    public void setCurrentList() {
+        this.currList = model.getCurrentList();
+    }
+
     @Override
     public CommandResult execute() throws CommandException {
+        List<?> lastShownList;
 
-        List<Person> lastShownList = model.getFilteredPersonList();
+        setCurrentList();
+
+        if (currList == 0) {
+            lastShownList = model.getFilteredClientList();
+        } else if (currList == 1) {
+            lastShownList = model.getFilteredPetList();
+        } else if (currList == 2) {
+            lastShownList = model.getFilteredVetTechnicianList();
+        } else {
+            throw new CommandException("Not currently on a list that 'select' command can work");
+        }
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        EventsCenter.getInstance().post(new JumpToListRequestEvent(targetIndex));
+        EventsCenter.getInstance().post(new JumpToListRequestEvent(targetIndex, currList));
+        if (currList == 1) {
+            return new CommandResult(String.format(MESSAGE_SELECT_PET_SUCCESS, targetIndex.getOneBased()));
+        }
         return new CommandResult(String.format(MESSAGE_SELECT_PERSON_SUCCESS, targetIndex.getOneBased()));
-
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -2,8 +2,10 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PET;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TECHNICIAN;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
@@ -40,6 +42,8 @@ public abstract class UndoableCommand extends Command {
         requireAllNonNull(model, previousAddressBook);
         model.resetData(previousAddressBook);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
+        model.updateFilteredVetTechnicianList(PREDICATE_SHOW_ALL_TECHNICIAN);
         model.updateFilteredPetList(PREDICATE_SHOW_ALL_PET);
     }
 
@@ -56,6 +60,8 @@ public abstract class UndoableCommand extends Command {
                     + "it should not fail now");
         }
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
+        model.updateFilteredVetTechnicianList(PREDICATE_SHOW_ALL_TECHNICIAN);
         model.updateFilteredPetList(PREDICATE_SHOW_ALL_PET);
     }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -33,7 +34,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME,
+                ArgumentTokenizer.tokenize(args, PREFIX_PERSON_ROLE, PREFIX_NAME,
                         PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
         Index index;
@@ -46,6 +47,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         try {
+            ParserUtil.parseRole(argMultimap.getValue(PREFIX_PERSON_ROLE)).ifPresent(editPersonDescriptor::setRole);
             ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME)).ifPresent(editPersonDescriptor::setName);
             ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE)).ifPresent(editPersonDescriptor::setPhone);
             ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL)).ifPresent(editPersonDescriptor::setEmail);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -34,7 +33,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_PERSON_ROLE, PREFIX_NAME,
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME,
                         PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
         Index index;
@@ -47,7 +46,6 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         try {
-            ParserUtil.parseRole(argMultimap.getValue(PREFIX_PERSON_ROLE)).ifPresent(editPersonDescriptor::setRole);
             ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME)).ifPresent(editPersonDescriptor::setName);
             ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE)).ifPresent(editPersonDescriptor::setPhone);
             ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL)).ifPresent(editPersonDescriptor::setEmail);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -19,84 +19,118 @@ import seedu.address.model.vettechnician.VetTechnician;
  * The API of the Model component.
  */
 public interface Model {
-    /** {@code Predicate} that always evaluate to true */
+    /**
+     * {@code Predicate} that always evaluate to true
+     */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
     Predicate<Client> PREDICATE_SHOW_ALL_CLIENTS = unused -> true;
     Predicate<VetTechnician> PREDICATE_SHOW_ALL_TECHNICIAN = unused -> true;
 
-    /** {@code Predicate} that always evaluate to true */
+    /**
+     * {@code Predicate} that always evaluate to true
+     */
     Predicate<Pet> PREDICATE_SHOW_ALL_PET = unused -> true;
 
-    /** Clears existing backing model and replaces with the provided new data. */
+    /**
+     * Clears existing backing model and replaces with the provided new data.
+     */
     void resetData(ReadOnlyAddressBook newData);
 
-    /** Returns the AddressBook */
+    /**
+     * Returns the AddressBook
+     */
     ReadOnlyAddressBook getAddressBook();
 
-    /** Deletes the given person. */
+    /**
+     * Deletes the given person.
+     */
     void deletePerson(Person target) throws PersonNotFoundException;
 
-    /** Adds the given person */
+    /**
+     * Adds the given person
+     */
     void addPerson(Person person) throws DuplicatePersonException;
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      *
      * @throws DuplicatePersonException if updating the person's details causes the person to be equivalent to
-     *      another existing person in the list.
-     * @throws PersonNotFoundException if {@code target} could not be found in the list.
+     *                                  another existing person in the list.
+     * @throws PersonNotFoundException  if {@code target} could not be found in the list.
      */
     void updatePerson(Person target, Person editedPerson)
             throws DuplicatePersonException, PersonNotFoundException;
 
-    /** Returns an unmodifiable view of the filtered person list */
+    /**
+     * Returns an unmodifiable view of the filtered person list
+     */
     ObservableList<Person> getFilteredPersonList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
 
-    /** Returns an unmodifiable view of the filtered client list */
+    /**
+     * Returns an unmodifiable view of the filtered client list
+     */
     ObservableList<Client> getFilteredClientList();
 
     /**
      * Updates the filter of the filtered client list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredClientList(Predicate<Client> predicate);
 
-    /** Returns an unmodifiable view of the filtered vetTechnician list */
+    /**
+     * Returns an unmodifiable view of the filtered vetTechnician list
+     */
     ObservableList<VetTechnician> getFilteredVetTechnicianList();
 
     /**
      * Updates the filter of the filtered vet technician list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredVetTechnicianList(Predicate<VetTechnician> predicate);
 
-    /** Schedule the given appointment according to date and time */
+    /**
+     * Schedule the given appointment according to date and time
+     */
     void scheduleAppointment(Appointment appointment) throws DuplicateAppointmentException;
 
-    /** Adds the given pet */
+    /**
+     * Adds the given pet
+     */
     void addPet(Pet pet) throws DuplicatePetException;
 
-    /** Removes the given pet */
+    /**
+     * Removes the given pet
+     */
     void deletePet(Pet pet) throws PetNotFoundException;
 
-    /** Returns an unmodifiable view of the filtered pet list */
+    /**
+     * Returns an unmodifiable view of the filtered pet list
+     */
     ObservableList<Pet> getFilteredPetList();
 
     /**
      * Updates the filter of the filtered pet list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPetList(Predicate<Pet> predicate);
 
-    /** Sets the index of the current list that is viewed */
+    /**
+     * Sets the index of the current list that is viewed
+     */
     void setCurrentList(int currList);
-    
-    /** Get the index of the current list that is viewed */
+
+    /**
+     * Get the index of the current list that is viewed
+     */
     int getCurrentList();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -93,4 +93,10 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPetList(Predicate<Pet> predicate);
+
+    /** Sets the index of the current list that is viewed */
+    void setCurrentList(int currList);
+    
+    /** Get the index of the current list that is viewed */
+    int getCurrentList();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -38,6 +38,7 @@ public class ModelManager extends ComponentManager implements Model {
     private final FilteredList<Client> filteredClients;
     private final FilteredList<VetTechnician> filteredVetTechnicians;
     private final FilteredList<Pet> filteredPet;
+    private int currList = 0;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -102,7 +103,9 @@ public class ModelManager extends ComponentManager implements Model {
         return addressBook;
     }
 
-    /** Raises an event to indicate the model has changed */
+    /**
+     * Raises an event to indicate the model has changed
+     */
     private void indicateAddressBookChanged() {
         raise(new AddressBookChangedEvent(addressBook));
     }
@@ -235,5 +238,15 @@ public class ModelManager extends ComponentManager implements Model {
                 && filteredPersons.equals(other.filteredPersons)
                 && filteredClients.equals(other.filteredClients)
                 && filteredVetTechnicians.equals(other.filteredVetTechnicians);
+    }
+
+    @Override
+    public void setCurrentList(int currList) {
+        this.currList = currList;
+    }
+
+    @Override
+    public int getCurrentList() {
+        return this.currList;
     }
 }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -28,4 +28,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
                 && this.keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
     }
 
+    public List<String> getKeywords() {
+        return keywords;
+    }
 }

--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -12,7 +12,9 @@ import javafx.scene.layout.Region;
 import javafx.scene.web.WebView;
 import seedu.address.MainApp;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.events.ui.ClientPanelSelectionChangedEvent;
 import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
+import seedu.address.commons.events.ui.VetTechnicianPanelSelectionChangedEvent;
 import seedu.address.model.person.Person;
 
 /**
@@ -68,5 +70,17 @@ public class BrowserPanel extends UiPart<Region> {
     private void handlePersonPanelSelectionChangedEvent(PersonPanelSelectionChangedEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
         loadPersonPage(event.getNewSelection().person);
+    }
+
+    @Subscribe
+    private void handleClientPanelSelectionChangedEvent(ClientPanelSelectionChangedEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event));
+        loadPersonPage(event.getNewSelection().client);
+    }
+
+    @Subscribe
+    private void handleVetTechnicianPanelSelectionChangedEvent(VetTechnicianPanelSelectionChangedEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event));
+        loadPersonPage(event.getNewSelection().vetTechnician);
     }
 }

--- a/src/main/java/seedu/address/ui/ClientListPanel.java
+++ b/src/main/java/seedu/address/ui/ClientListPanel.java
@@ -64,7 +64,9 @@ public class ClientListPanel extends UiPart<Region> {
     @Subscribe
     private void handleJumpToListRequestEvent(JumpToListRequestEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        scrollTo(event.targetIndex);
+        if (event.targetList == 0) {
+            scrollTo(event.targetIndex);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/ui/ClientListPanel.java
+++ b/src/main/java/seedu/address/ui/ClientListPanel.java
@@ -1,0 +1,88 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import org.fxmisc.easybind.EasyBind;
+
+import com.google.common.eventbus.Subscribe;
+
+import javafx.application.Platform;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.events.ui.ClientPanelSelectionChangedEvent;
+import seedu.address.commons.events.ui.JumpToListRequestEvent;
+import seedu.address.model.client.Client;
+
+/**
+ * Panel containing the list of clients.
+ */
+public class ClientListPanel extends UiPart<Region> {
+    private static final String FXML = "ClientListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(ClientListPanel.class);
+
+    @FXML
+    private ListView<ClientCard> clientListView;
+
+    public ClientListPanel(ObservableList<Client> clientList) {
+        super(FXML);
+        setConnections(clientList);
+        registerAsAnEventHandler(this);
+    }
+
+    private void setConnections(ObservableList<Client> clientList) {
+        ObservableList<ClientCard> mappedList = EasyBind.map(
+                clientList, (client) -> new ClientCard(client, clientList.indexOf(client) + 1));
+        clientListView.setItems(mappedList);
+        clientListView.setCellFactory(listView -> new ClientListViewCell());
+        setEventHandlerForSelectionChangeEvent();
+    }
+
+    private void setEventHandlerForSelectionChangeEvent() {
+        clientListView.getSelectionModel().selectedItemProperty()
+                .addListener((observable, oldValue, newValue) -> {
+                    if (newValue != null) {
+                        logger.fine("Selection in client list panel changed to : '" + newValue + "'");
+                        raise(new ClientPanelSelectionChangedEvent(newValue));
+                    }
+                });
+    }
+
+    /**
+     * Scrolls to the {@code ClientCard} at the {@code index} and selects it.
+     */
+    private void scrollTo(int index) {
+        Platform.runLater(() -> {
+            clientListView.scrollTo(index);
+            clientListView.getSelectionModel().clearAndSelect(index);
+        });
+    }
+
+    @Subscribe
+    private void handleJumpToListRequestEvent(JumpToListRequestEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event));
+        scrollTo(event.targetIndex);
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code ClientCard}.
+     */
+    class ClientListViewCell extends ListCell<ClientCard> {
+
+        @Override
+        protected void updateItem(ClientCard client, boolean empty) {
+            super.updateItem(client, empty);
+
+            if (empty || client == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(client.getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -5,6 +5,8 @@ import java.util.logging.Logger;
 import com.google.common.eventbus.Subscribe;
 
 import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
@@ -227,7 +229,20 @@ public class MainWindow extends UiPart<Stage> {
     @Subscribe
     private void handleChangeListTabEvent(ChangeListTabEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        changeTo(event.targetIndex);
+        changeTo(event.targetList);
+        updateCurrentList();
+    }
+
+    /**
+     * Updates the current index being viewed
+     */
+    private void updateCurrentList() {
+        listPanel.getSelectionModel().selectedIndexProperty().addListener(new ChangeListener<Number>() {
+            @Override
+            public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+                logic.setCurrentList(newValue.intValue());
+            }
+        });
     }
 
     void releaseResources() {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -40,6 +40,7 @@ public class MainWindow extends UiPart<Stage> {
     private BrowserPanel browserPanel;
     private PersonListPanel personListPanel;
     private PetListPanel petListPanel;
+    private VetTechnicianListPanel vetTechnicianListPanel;
     private Config config;
     private UserPrefs prefs;
 
@@ -57,6 +58,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane petListPanelPlaceholder;
+
+    @FXML
+    private StackPane vetTechnicianPlaceholder;
 
     @FXML
     private TabPane listPanel;
@@ -135,6 +139,9 @@ public class MainWindow extends UiPart<Stage> {
 
         petListPanel = new PetListPanel(logic.getFilteredPetList());
         petListPanelPlaceholder.getChildren().add(petListPanel.getRoot());
+
+        //vetTechnicianListPanel = new VetTechnicianListPanel(logic.getFilteredVetTechnicianList());
+        //vetTechnicianPlaceholder.getChildren().add(vetTechnicianListPanel.getRoot());
 
         ResultDisplay resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -38,7 +38,7 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private BrowserPanel browserPanel;
-    private PersonListPanel personListPanel;
+    private ClientListPanel clientListPanel;
     private PetListPanel petListPanel;
     private VetTechnicianListPanel vetTechnicianListPanel;
     private Config config;
@@ -54,13 +54,13 @@ public class MainWindow extends UiPart<Stage> {
     private MenuItem helpMenuItem;
 
     @FXML
-    private StackPane personListPanelPlaceholder;
+    private StackPane clientListPanelPlaceholder;
 
     @FXML
     private StackPane petListPanelPlaceholder;
 
     @FXML
-    private StackPane vetTechnicianPlaceholder;
+    private StackPane vetTechnicianListPanelPlaceholder;
 
     @FXML
     private TabPane listPanel;
@@ -134,14 +134,14 @@ public class MainWindow extends UiPart<Stage> {
         browserPanel = new BrowserPanel();
         browserPlaceholder.getChildren().add(browserPanel.getRoot());
 
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
-        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        clientListPanel = new ClientListPanel(logic.getFilteredClientList());
+        clientListPanelPlaceholder.getChildren().add(clientListPanel.getRoot());
 
         petListPanel = new PetListPanel(logic.getFilteredPetList());
         petListPanelPlaceholder.getChildren().add(petListPanel.getRoot());
 
-        //vetTechnicianListPanel = new VetTechnicianListPanel(logic.getFilteredVetTechnicianList());
-        //vetTechnicianPlaceholder.getChildren().add(vetTechnicianListPanel.getRoot());
+        vetTechnicianListPanel = new VetTechnicianListPanel(logic.getFilteredVetTechnicianList());
+        vetTechnicianListPanelPlaceholder.getChildren().add(vetTechnicianListPanel.getRoot());
 
         ResultDisplay resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -202,13 +202,18 @@ public class MainWindow extends UiPart<Stage> {
         raise(new ExitAppRequestEvent());
     }
 
-    public PersonListPanel getPersonListPanel() {
-        return this.personListPanel;
+    public ClientListPanel getClientListPanel() {
+        return this.clientListPanel;
     }
 
     public PetListPanel getPetListPanel() {
         return this.petListPanel;
     }
+
+    public VetTechnicianListPanel getVetTechnicianListPanel() {
+        return this.vetTechnicianListPanel;
+    }
+
 
     /**
      * Changes to the {@code Tab} at the {@code index} and selects it.

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -17,7 +17,6 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.Config;
-import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.ui.ChangeListTabEvent;
@@ -243,7 +242,7 @@ public class MainWindow extends UiPart<Stage> {
         listPanel.getSelectionModel().selectedIndexProperty().addListener(new ChangeListener<Number>() {
             @Override
             public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
-                EventsCenter.getInstance().post(new ChangeListTabEvent(newValue.intValue()));
+                logic.setCurrentList(newValue.intValue());
             }
         });
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -17,6 +17,7 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.Config;
+import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.ui.ChangeListTabEvent;
@@ -88,6 +89,8 @@ public class MainWindow extends UiPart<Stage> {
 
         setAccelerators();
         registerAsAnEventHandler(this);
+
+        updateCurrentList();
     }
 
     public Stage getPrimaryStage() {
@@ -218,11 +221,11 @@ public class MainWindow extends UiPart<Stage> {
 
 
     /**
-     * Changes to the {@code Tab} at the {@code index} and selects it.
+     * Changes to the {@code Tab} of the specific {@code list} requested and selects it.
      */
-    private void changeTo(int index) {
+    private void changeTo(int list) {
         Platform.runLater(() -> {
-            listPanel.getSelectionModel().select(index);
+            listPanel.getSelectionModel().select(list);
         });
     }
 
@@ -230,17 +233,17 @@ public class MainWindow extends UiPart<Stage> {
     private void handleChangeListTabEvent(ChangeListTabEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
         changeTo(event.targetList);
-        updateCurrentList();
+        logic.setCurrentList(event.targetList);
     }
 
     /**
-     * Updates the current index being viewed
+     * Updates the current index being viewed if tab is changed by mouseclick event
      */
     private void updateCurrentList() {
         listPanel.getSelectionModel().selectedIndexProperty().addListener(new ChangeListener<Number>() {
             @Override
             public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
-                logic.setCurrentList(newValue.intValue());
+                EventsCenter.getInstance().post(new ChangeListTabEvent(newValue.intValue()));
             }
         });
     }

--- a/src/main/java/seedu/address/ui/PetListPanel.java
+++ b/src/main/java/seedu/address/ui/PetListPanel.java
@@ -64,7 +64,9 @@ public class PetListPanel extends UiPart<Region> {
     @Subscribe
     private void handleJumpToListRequestEvent(JumpToListRequestEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        scrollTo(event.targetIndex);
+        if (event.targetList == 1) {
+            scrollTo(event.targetIndex);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/ui/VetTechnicianCard.java
+++ b/src/main/java/seedu/address/ui/VetTechnicianCard.java
@@ -50,7 +50,7 @@ public class VetTechnicianCard extends UiPart<Region> {
         phone.setText(vetTechnician.getPhone().value);
         address.setText(vetTechnician.getAddress().value);
         email.setText(vetTechnician.getEmail().value);
-        vetTechnician.getTags().forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        initTags(vetTechnician);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/VetTechnicianListPanel.java
+++ b/src/main/java/seedu/address/ui/VetTechnicianListPanel.java
@@ -1,0 +1,89 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import org.fxmisc.easybind.EasyBind;
+
+import com.google.common.eventbus.Subscribe;
+
+import javafx.application.Platform;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.events.ui.JumpToListRequestEvent;
+import seedu.address.commons.events.ui.VetTechnicianPanelSelectionChangedEvent;
+import seedu.address.model.vettechnician.VetTechnician;
+
+/**
+ * Panel containing the list of vetTechnicians.
+ */
+public class VetTechnicianListPanel extends UiPart<Region> {
+    private static final String FXML = "VetTechnicianListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(VetTechnicianListPanel.class);
+
+    @FXML
+    private ListView<VetTechnicianCard> vetTechnicianListView;
+
+    public VetTechnicianListPanel(ObservableList<VetTechnician> vetTechnicianList) {
+        super(FXML);
+        setConnections(vetTechnicianList);
+        registerAsAnEventHandler(this);
+    }
+
+    private void setConnections(ObservableList<VetTechnician> vetTechnicianList) {
+        ObservableList<VetTechnicianCard> mappedList = EasyBind.map(
+                vetTechnicianList, (vetTechnician) ->
+                        new VetTechnicianCard(vetTechnician, vetTechnicianList.indexOf(vetTechnician) + 1));
+        vetTechnicianListView.setItems(mappedList);
+        vetTechnicianListView.setCellFactory(listView -> new VetTechnicianListViewCell());
+        setEventHandlerForSelectionChangeEvent();
+    }
+
+    private void setEventHandlerForSelectionChangeEvent() {
+        vetTechnicianListView.getSelectionModel().selectedItemProperty()
+                .addListener((observable, oldValue, newValue) -> {
+                    if (newValue != null) {
+                        logger.fine("Selection in vetTechnician list panel changed to : '" + newValue + "'");
+                        raise(new VetTechnicianPanelSelectionChangedEvent(newValue));
+                    }
+                });
+    }
+
+    /**
+     * Scrolls to the {@code VetTechnicianCard} at the {@code index} and selects it.
+     */
+    private void scrollTo(int index) {
+        Platform.runLater(() -> {
+            vetTechnicianListView.scrollTo(index);
+            vetTechnicianListView.getSelectionModel().clearAndSelect(index);
+        });
+    }
+
+    @Subscribe
+    private void handleJumpToListRequestEvent(JumpToListRequestEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event));
+        scrollTo(event.targetIndex);
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code VetTechnicianCard}.
+     */
+    class VetTechnicianListViewCell extends ListCell<VetTechnicianCard> {
+
+        @Override
+        protected void updateItem(VetTechnicianCard vetTechnician, boolean empty) {
+            super.updateItem(vetTechnician, empty);
+
+            if (empty || vetTechnician == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(vetTechnician.getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/ui/VetTechnicianListPanel.java
+++ b/src/main/java/seedu/address/ui/VetTechnicianListPanel.java
@@ -65,7 +65,9 @@ public class VetTechnicianListPanel extends UiPart<Region> {
     @Subscribe
     private void handleJumpToListRequestEvent(JumpToListRequestEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        scrollTo(event.targetIndex);
+        if (event.targetList == 2) {
+            scrollTo(event.targetIndex);
+        }
     }
 
     /**

--- a/src/main/resources/view/ClientListPanel.fxml
+++ b/src/main/resources/view/ClientListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
+    <ListView fx:id="clientListView" prefWidth="248.0" VBox.vgrow="ALWAYS"/>
+</VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -68,7 +68,7 @@
                 </Tab>
                 <Tab text=" Vet Tech ">
                   <content>
-                    <ListView prefHeight="427.0" prefWidth="248.0"/>
+                    <StackPane fx:id="vetTechnicianListPanelPlaceholder" prefHeight="427.0" prefWidth="248.0" />
                   </content>
                 </Tab>
               </tabs>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -58,7 +58,7 @@
               <tabs>
                 <Tab text="  Client  ">
                   <content>
-                    <StackPane fx:id="personListPanelPlaceholder" prefHeight="427.0" prefWidth="248.0" />
+                    <StackPane fx:id="clientListPanelPlaceholder" prefHeight="427.0" prefWidth="248.0" />
                   </content>
                 </Tab>
                 <Tab text="    Pet    ">

--- a/src/main/resources/view/VetTechnicianListPanel.fxml
+++ b/src/main/resources/view/VetTechnicianListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
+    <ListView fx:id="vetTechnicianListView" prefWidth="248.0" VBox.vgrow="ALWAYS"/>
+</VBox>

--- a/src/test/java/guitests/guihandles/ClientCardHandle.java
+++ b/src/test/java/guitests/guihandles/ClientCardHandle.java
@@ -1,0 +1,71 @@
+package guitests.guihandles;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Region;
+
+/**
+ * Provides a handle to a client card in the client list panel.
+ */
+public class ClientCardHandle extends NodeHandle<Node> {
+    private static final String ID_FIELD_ID = "#id";
+    private static final String NAME_FIELD_ID = "#name";
+    private static final String ADDRESS_FIELD_ID = "#address";
+    private static final String PHONE_FIELD_ID = "#phone";
+    private static final String EMAIL_FIELD_ID = "#email";
+    private static final String TAGS_FIELD_ID = "#tags";
+
+    private final Label idLabel;
+    private final Label nameLabel;
+    private final Label addressLabel;
+    private final Label phoneLabel;
+    private final Label emailLabel;
+    private final List<Label> tagLabels;
+
+    public ClientCardHandle(Node cardNode) {
+        super(cardNode);
+
+        this.idLabel = getChildNode(ID_FIELD_ID);
+        this.nameLabel = getChildNode(NAME_FIELD_ID);
+        this.addressLabel = getChildNode(ADDRESS_FIELD_ID);
+        this.phoneLabel = getChildNode(PHONE_FIELD_ID);
+        this.emailLabel = getChildNode(EMAIL_FIELD_ID);
+
+        Region tagsContainer = getChildNode(TAGS_FIELD_ID);
+        this.tagLabels = tagsContainer
+                .getChildrenUnmodifiable()
+                .stream()
+                .map(Label.class::cast)
+                .collect(Collectors.toList());
+    }
+
+    public String getId() {
+        return idLabel.getText();
+    }
+
+    public String getName() {
+        return nameLabel.getText();
+    }
+
+    public String getAddress() {
+        return addressLabel.getText();
+    }
+
+    public String getPhone() {
+        return phoneLabel.getText();
+    }
+
+    public String getEmail() {
+        return emailLabel.getText();
+    }
+
+    public List<String> getTags() {
+        return tagLabels
+                .stream()
+                .map(Label::getText)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/guitests/guihandles/ClientListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/ClientListPanelHandle.java
@@ -1,0 +1,134 @@
+package guitests.guihandles;
+
+import java.util.List;
+import java.util.Optional;
+
+import javafx.scene.control.ListView;
+import seedu.address.model.client.Client;
+import seedu.address.ui.ClientCard;
+
+/**
+ * Provides a handle for {@code ClientListPanel} containing the list of {@code ClientCard}.
+ */
+public class ClientListPanelHandle extends NodeHandle<ListView<ClientCard>> {
+    public static final String CLIENT_LIST_VIEW_ID = "#clientListView";
+
+    private Optional<ClientCard> lastRememberedSelectedClientCard;
+
+    public ClientListPanelHandle(ListView<ClientCard> clientListPanelNode) {
+        super(clientListPanelNode);
+    }
+
+    /**
+     * Returns a handle to the selected {@code ClientCardHandle}.
+     * A maximum of 1 item can be selected at any time.
+     * @throws AssertionError if no card is selected, or more than 1 card is selected.
+     */
+    public ClientCardHandle getHandleToSelectedCard() {
+        List<ClientCard> clientList = getRootNode().getSelectionModel().getSelectedItems();
+
+        if (clientList.size() != 1) {
+            throw new AssertionError("Client list size expected 1.");
+        }
+
+        return new ClientCardHandle(clientList.get(0).getRoot());
+    }
+
+    /**
+     * Returns the index of the selected card.
+     */
+    public int getSelectedCardIndex() {
+        return getRootNode().getSelectionModel().getSelectedIndex();
+    }
+
+    /**
+     * Returns true if a card is currently selected.
+     */
+    public boolean isAnyCardSelected() {
+        List<ClientCard> selectedCardsList = getRootNode().getSelectionModel().getSelectedItems();
+
+        if (selectedCardsList.size() > 1) {
+            throw new AssertionError("Card list size expected 0 or 1.");
+        }
+
+        return !selectedCardsList.isEmpty();
+    }
+
+    /**
+     * Navigates the listview to display and select the client.
+     */
+    public void navigateToCard(Client client) {
+        List<ClientCard> cards = getRootNode().getItems();
+        Optional<ClientCard> matchingCard = cards.stream().filter(card -> card.client.equals(client)).findFirst();
+
+        if (!matchingCard.isPresent()) {
+            throw new IllegalArgumentException("Client does not exist.");
+        }
+
+        guiRobot.interact(() -> {
+            getRootNode().scrollTo(matchingCard.get());
+            getRootNode().getSelectionModel().select(matchingCard.get());
+        });
+        guiRobot.pauseForHuman();
+    }
+
+    /**
+     * Returns the client card handle of a client associated with the {@code index} in the list.
+     */
+    public ClientCardHandle getClientCardHandle(int index) {
+        return getClientCardHandle(getRootNode().getItems().get(index).client);
+    }
+
+    /**
+     * Returns the {@code ClientCardHandle} of the specified {@code client} in the list.
+     */
+    public ClientCardHandle getClientCardHandle(Client client) {
+        Optional<ClientCardHandle> handle = getRootNode().getItems().stream()
+                .filter(card -> card.client.equals(client))
+                .map(card -> new ClientCardHandle(card.getRoot()))
+                .findFirst();
+        return handle.orElseThrow(() -> new IllegalArgumentException("Client does not exist."));
+    }
+
+    /**
+     * Selects the {@code ClientCard} at {@code index} in the list.
+     */
+    public void select(int index) {
+        getRootNode().getSelectionModel().select(index);
+    }
+
+    /**
+     * Remembers the selected {@code ClientCard} in the list.
+     */
+    public void rememberSelectedClientCard() {
+        List<ClientCard> selectedItems = getRootNode().getSelectionModel().getSelectedItems();
+
+        if (selectedItems.size() == 0) {
+            lastRememberedSelectedClientCard = Optional.empty();
+        } else {
+            lastRememberedSelectedClientCard = Optional.of(selectedItems.get(0));
+        }
+    }
+
+    /**
+     * Returns true if the selected {@code ClientCard} is different from the value remembered by the most recent
+     * {@code rememberSelectedClientCard()} call.
+     */
+    public boolean isSelectedClientCardChanged() {
+        List<ClientCard> selectedItems = getRootNode().getSelectionModel().getSelectedItems();
+
+        if (selectedItems.size() == 0) {
+            return lastRememberedSelectedClientCard.isPresent();
+        } else {
+            return !lastRememberedSelectedClientCard.isPresent()
+                    || !lastRememberedSelectedClientCard.get().equals(selectedItems.get(0));
+        }
+    }
+
+    /**
+     * Returns the size of the list.
+     */
+    public int getListSize() {
+        return getRootNode().getItems().size();
+    }
+}

--- a/src/test/java/guitests/guihandles/MainWindowHandle.java
+++ b/src/test/java/guitests/guihandles/MainWindowHandle.java
@@ -7,7 +7,8 @@ import javafx.stage.Stage;
  */
 public class MainWindowHandle extends StageHandle {
 
-    private final PersonListPanelHandle personListPanel;
+    //private final PersonListPanelHandle personListPanel;
+    private final ClientListPanelHandle clientListPanel;
     private final ResultDisplayHandle resultDisplay;
     private final CommandBoxHandle commandBox;
     private final StatusBarFooterHandle statusBarFooter;
@@ -17,7 +18,8 @@ public class MainWindowHandle extends StageHandle {
     public MainWindowHandle(Stage stage) {
         super(stage);
 
-        personListPanel = new PersonListPanelHandle(getChildNode(PersonListPanelHandle.PERSON_LIST_VIEW_ID));
+        clientListPanel = new ClientListPanelHandle(getChildNode(ClientListPanelHandle.CLIENT_LIST_VIEW_ID));
+        //personListPanel = new PersonListPanelHandle(getChildNode(PersonListPanelHandle.PERSON_LIST_VIEW_ID));
         resultDisplay = new ResultDisplayHandle(getChildNode(ResultDisplayHandle.RESULT_DISPLAY_ID));
         commandBox = new CommandBoxHandle(getChildNode(CommandBoxHandle.COMMAND_INPUT_FIELD_ID));
         statusBarFooter = new StatusBarFooterHandle(getChildNode(StatusBarFooterHandle.STATUS_BAR_PLACEHOLDER));
@@ -25,9 +27,13 @@ public class MainWindowHandle extends StageHandle {
         browserPanel = new BrowserPanelHandle(getChildNode(BrowserPanelHandle.BROWSER_ID));
     }
 
-    public PersonListPanelHandle getPersonListPanel() {
-        return personListPanel;
+    public ClientListPanelHandle getClientListPanel() {
+        return clientListPanel;
     }
+
+    /*public PersonListPanelHandle getPersonListPanel() {
+        return personListPanel;
+    }*/
 
     public ResultDisplayHandle getResultDisplay() {
         return resultDisplay;

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -95,7 +95,7 @@ public class TestApp extends MainApp {
      */
     public Model getModel() {
         Model copy = new ModelManager((model.getAddressBook()), new UserPrefs());
-        ModelHelper.setFilteredList(copy, model.getFilteredPersonList());
+        ModelHelper.setFilteredList(copy, model.getFilteredClientList(), model.getFilteredVetTechnicianList());
         return copy;
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -186,6 +186,17 @@ public class AddCommandTest {
         public void deletePet(Pet pet) throws PetNotFoundException {
             fail("This method should not be called");
         }
+
+        @Override
+        public void setCurrentList(int currentList) {
+            fail("This method should not be called");
+        }
+
+        @Override
+        public int getCurrentList() {
+            fail("This method should not be called");
+            return -1;
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -253,6 +253,18 @@ public class AddCommandTest {
         public ReadOnlyAddressBook getAddressBook() {
             return new AddressBook();
         }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) { }
+
+        @Override
+        public void updateFilteredVetTechnicianList(Predicate<VetTechnician> predicate) { }
+
+        @Override
+        public void updateFilteredPetList(Predicate<Pet> predicate) { }
+
+        @Override
+        public void updateFilteredClientList(Predicate<Client> predicate) { }
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddPetCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPetCommandTest.java
@@ -98,6 +98,7 @@ public class AddPetCommandTest {
         command.setData(model, new CommandHistory(), new UndoRedoStack());
         return command;
     }
+
     /**
      * Default model stub that has all the methods failing
      */
@@ -185,6 +186,17 @@ public class AddPetCommandTest {
         public void deletePet(Pet pet) throws PetNotFoundException {
             fail("This method should not be called");
         }
+
+        @Override
+        public void setCurrentList(int currentList) {
+            fail("This method should not be called");
+        }
+
+        @Override
+        public int getCurrentList() {
+            fail("This method should not be called");
+            return -1;
+        }
     }
 
     /**
@@ -213,6 +225,7 @@ public class AddPetCommandTest {
             requireNonNull(pet);
             petsAdded.add(pet);
         }
+
         @Override
         public ReadOnlyAddressBook getAddressBook() {
             return new AddressBook();

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -13,6 +13,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
@@ -20,6 +21,7 @@ import seedu.address.logic.UndoRedoStack;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.client.Client;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
@@ -120,13 +122,18 @@ public class CommandTestUtil {
      * {@code model}'s address book.
      */
     public static void showPersonAtIndex(Model model, Index targetIndex) {
-        assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredClientList().size());
 
-        Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
-        final String[] splitName = person.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        Person clientToBeShownAtIndex = model.getFilteredClientList().get(targetIndex.getZeroBased());
+        final String[] splitName = clientToBeShownAtIndex.getName().fullName.split("\\s+");
+        model.updateFilteredClientList(new Predicate<Client>() {
+            @Override
+            public boolean test(Client client) {
+                return clientToBeShownAtIndex.equals(client);
+            }
+        });
 
-        assertEquals(1, model.getFilteredPersonList().size());
+        assertEquals(1, model.getFilteredClientList().size());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -123,9 +123,15 @@ public class CommandTestUtil {
      */
     public static void showPersonAtIndex(Model model, Index targetIndex) {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredClientList().size());
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
+
+        Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
+        final String[] splitName = person.getName().fullName.split("\\s+");
+        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredPersonList().size());
 
         Person clientToBeShownAtIndex = model.getFilteredClientList().get(targetIndex.getZeroBased());
-        final String[] splitName = clientToBeShownAtIndex.getName().fullName.split("\\s+");
         model.updateFilteredClientList(new Predicate<Client>() {
             @Override
             public boolean test(Client client) {

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -56,7 +56,7 @@ public class DeleteCommandTest {
     public void execute_validIndexFilteredList_success() throws Exception {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete = model.getFilteredClientList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = prepareCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
@@ -134,7 +134,7 @@ public class DeleteCommandTest {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
         showPersonAtIndex(model, INDEX_SECOND_PERSON);
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete = model.getFilteredClientList().get(INDEX_FIRST_PERSON.getZeroBased());
         // delete -> deletes second person in unfiltered person list / first person in filtered person list
         deleteCommand.execute();
         undoRedoStack.push(deleteCommand);
@@ -143,7 +143,7 @@ public class DeleteCommandTest {
         assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
         expectedModel.deletePerson(personToDelete);
-        assertNotEquals(personToDelete, model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()));
+        assertNotEquals(personToDelete, model.getFilteredClientList().get(INDEX_FIRST_PERSON.getZeroBased()));
         // redo -> deletes same second person in unfiltered person list
         assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
     }
@@ -188,7 +188,9 @@ public class DeleteCommandTest {
      */
     private void showNoPerson(Model model) {
         model.updateFilteredPersonList(p -> false);
+        model.updateFilteredClientList(p ->false);
 
         assertTrue(model.getFilteredPersonList().isEmpty());
+        assertTrue(model.getFilteredClientList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -105,8 +105,8 @@ public class EditCommandTest {
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
 
         // edit client to vet technician
-        personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        editedPerson = new PersonBuilder(personInFilteredList)
+        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(personInFilteredList)
                 .withName(VALID_NAME_BOB).buildWithRoleVetTechnician();
         editCommand = prepareCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).withRole(VALID_ROLE_TECHNICIAN).build());

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -88,17 +88,16 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() throws Exception {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).buildWithRoleClient();
+        Person clientInFilteredList = model.getFilteredClientList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedClient = new PersonBuilder(clientInFilteredList).withName(VALID_NAME_BOB).buildWithRoleClient();
         EditCommand editCommand = prepareCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedClient);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.updatePerson(model.getFilteredClientList().get(0), editedClient);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -57,12 +57,12 @@ public class EditCommandTest {
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() throws Exception {
-        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
-        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredClientList().size());
+        Person lastPerson = model.getFilteredClientList().get(indexLastPerson.getZeroBased());
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTags(VALID_TAG_HUSBAND).buildWithRoleVetTechnician();
+                .withTags(VALID_TAG_HUSBAND).buildWithRoleClient();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
@@ -105,8 +105,8 @@ public class EditCommandTest {
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
 
         // edit client to vet technician
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(personInFilteredList)
+        clientInFilteredList = model.getFilteredClientList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(clientInFilteredList)
                 .withName(VALID_NAME_BOB).buildWithRoleVetTechnician();
         editCommand = prepareCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).withRole(VALID_ROLE_TECHNICIAN).build());
@@ -114,20 +114,23 @@ public class EditCommandTest {
         expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.updatePerson(model.getFilteredClientList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
 
         // edit vet technician to client
-        editedPerson = new PersonBuilder(personInFilteredList)
+        model.setCurrentList(2);
+        Person technicianInFilteredList = model.getFilteredVetTechnicianList().get(INDEX_FIRST_PERSON.getZeroBased());
+        editedPerson = new PersonBuilder(technicianInFilteredList)
                 .withName(VALID_NAME_BOB).buildWithRoleClient();
         editCommand = prepareCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).withRole(VALID_ROLE_CLIENT).build());
+        editCommand.setCurrentList();
 
         expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.updatePerson(model.getFilteredVetTechnicianList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -83,16 +83,16 @@ public class FindCommandTest {
 
     /**
      * Asserts that {@code command} is successfully executed, and<br>
-     *     - the command feedback is equal to {@code expectedMessage}<br>
-     *     - the {@code FilteredList<Person>} is equal to {@code expectedList}<br>
-     *     - the {@code AddressBook} in model remains the same after executing the {@code command}
+     * - the command feedback is equal to {@code expectedMessage}<br>
+     * - the {@code FilteredList<Person>} is equal to {@code expectedList}<br>
+     * - the {@code AddressBook} in model remains the same after executing the {@code command}
      */
     private void assertCommandSuccess(FindCommand command, String expectedMessage, List<Person> expectedList) {
         AddressBook expectedAddressBook = new AddressBook(model.getAddressBook());
         CommandResult commandResult = command.execute();
-
+        
         assertEquals(expectedMessage, commandResult.feedbackToUser);
-        assertEquals(expectedList, model.getFilteredPersonList());
+        assertEquals(expectedList, model.getFilteredClientList());
         assertEquals(expectedAddressBook, model.getAddressBook());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -90,7 +90,7 @@ public class FindCommandTest {
     private void assertCommandSuccess(FindCommand command, String expectedMessage, List<Person> expectedList) {
         AddressBook expectedAddressBook = new AddressBook(model.getAddressBook());
         CommandResult commandResult = command.execute();
-        
+
         assertEquals(expectedMessage, commandResult.feedbackToUser);
         assertEquals(expectedList, model.getFilteredClientList());
         assertEquals(expectedAddressBook, model.getAddressBook());

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+//import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+//import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Before;

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -41,7 +41,7 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        //showPersonAtIndex(model, INDEX_FIRST_PERSON);
         assertCommandSuccess(listCommand, model, LIST_EXPECTED_MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ScheduleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ScheduleCommandTest.java
@@ -186,6 +186,17 @@ public class ScheduleCommandTest {
         public void deletePet(Pet pet) throws PetNotFoundException {
             fail("This method should not be called");
         }
+
+        @Override
+        public void setCurrentList(int currentList) {
+            fail("This method should not be called");
+        }
+
+        @Override
+        public int getCurrentList() {
+            fail("This method should not be called");
+            return -1;
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
@@ -41,7 +41,7 @@ public class SelectCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Index lastPersonIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+        Index lastPersonIndex = Index.fromOneBased(model.getFilteredClientList().size());
 
         assertExecutionSuccess(INDEX_FIRST_PERSON);
         assertExecutionSuccess(INDEX_THIRD_PERSON);

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -42,7 +42,7 @@ public class TestUtil {
      * Returns the last index of the person in the {@code model}'s person list.
      */
     public static Index getLastIndex(Model model) {
-        return Index.fromOneBased(model.getAddressBook().getPersonList().size());
+        return Index.fromOneBased(model.getFilteredClientList().size());
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -42,7 +42,7 @@ public class TypicalPersons {
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").buildWithRoleClient();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").buildWithRoleClient();
+            .withEmail("anna@example.com").withAddress("4th street").buildWithRoleVetTechnician();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -42,7 +42,7 @@ public class TypicalPersons {
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").buildWithRoleClient();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").buildWithRoleVetTechnician();
+            .withEmail("anna@example.com").withAddress("4th street").buildWithRoleClient();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -21,7 +21,8 @@ public class PersonListPanelTest extends GuiUnitTest {
     private static final ObservableList<Person> TYPICAL_PERSONS =
             FXCollections.observableList(getTypicalPersons());
 
-    private static final JumpToListRequestEvent JUMP_TO_SECOND_EVENT = new JumpToListRequestEvent(INDEX_SECOND_PERSON);
+    private static final JumpToListRequestEvent JUMP_TO_SECOND_EVENT =
+            new JumpToListRequestEvent(INDEX_SECOND_PERSON, 0);
 
     private PersonListPanelHandle personListPanelHandle;
 

--- a/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
@@ -54,7 +54,7 @@ public class GuiTestAssert {
     }
 
     /**
-     * Asserts that the list in {@code personListPanelHandle} displays the details of {@code persons} correctly and
+     * Asserts that the list in {@code clientListPanelHandle} displays the details of {@code persons} correctly and
      * in the correct order.
      */
     public static void assertListMatching(ClientListPanelHandle clientListPanelHandle, Person... persons) {

--- a/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
@@ -5,9 +5,12 @@ import static org.junit.Assert.assertEquals;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import guitests.guihandles.ClientCardHandle;
+import guitests.guihandles.ClientListPanelHandle;
 import guitests.guihandles.PersonCardHandle;
 import guitests.guihandles.PersonListPanelHandle;
 import guitests.guihandles.ResultDisplayHandle;
+import seedu.address.model.client.Client;
 import seedu.address.model.person.Person;
 
 /**
@@ -39,12 +42,24 @@ public class GuiTestAssert {
     }
 
     /**
+     * Asserts that {@code actualCard} displays the details of {@code expectedPerson}.
+     */
+    public static void assertCardDisplaysClient(Person expectedPerson, ClientCardHandle actualCard) {
+        assertEquals(expectedPerson.getName().fullName, actualCard.getName());
+        assertEquals(expectedPerson.getPhone().value, actualCard.getPhone());
+        assertEquals(expectedPerson.getEmail().value, actualCard.getEmail());
+        assertEquals(expectedPerson.getAddress().value, actualCard.getAddress());
+        assertEquals(expectedPerson.getTags().stream().map(tag -> tag.tagName).collect(Collectors.toList()),
+                actualCard.getTags());
+    }
+
+    /**
      * Asserts that the list in {@code personListPanelHandle} displays the details of {@code persons} correctly and
      * in the correct order.
      */
-    public static void assertListMatching(PersonListPanelHandle personListPanelHandle, Person... persons) {
+    public static void assertListMatching(ClientListPanelHandle clientListPanelHandle, Person... persons) {
         for (int i = 0; i < persons.length; i++) {
-            assertCardDisplaysPerson(persons[i], personListPanelHandle.getPersonCardHandle(i));
+            assertCardDisplaysClient(persons[i], clientListPanelHandle.getClientCardHandle(i));
         }
     }
 
@@ -52,8 +67,8 @@ public class GuiTestAssert {
      * Asserts that the list in {@code personListPanelHandle} displays the details of {@code persons} correctly and
      * in the correct order.
      */
-    public static void assertListMatching(PersonListPanelHandle personListPanelHandle, List<Person> persons) {
-        assertListMatching(personListPanelHandle, persons.toArray(new Person[0]));
+    public static void assertListMatching(ClientListPanelHandle clientListPanelHandle, List<Client> clients) {
+        assertListMatching(clientListPanelHandle, clients.toArray(new Person[0]));
     }
 
     /**

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -28,6 +28,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TECHNICIAN;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -60,6 +63,9 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
     @Test
     public void add() throws Exception {
         Model model = getModel();
+        model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredVetTechnicianList(PREDICATE_SHOW_ALL_TECHNICIAN);
 
         /* ------------------------ Perform add operations on the shown unfiltered list ----------------------------- */
 
@@ -237,6 +243,9 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         Model expectedModel = getModel();
         try {
             expectedModel.addPerson(toAdd);
+            expectedModel.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
+            expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            expectedModel.updateFilteredVetTechnicianList(PREDICATE_SHOW_ALL_TECHNICIAN);
         } catch (DuplicatePersonException dpe) {
             throw new IllegalArgumentException("toAdd already exists in the model.");
         }

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -22,6 +22,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
 import guitests.guihandles.BrowserPanelHandle;
+import guitests.guihandles.ClientListPanelHandle;
 import guitests.guihandles.CommandBoxHandle;
 import guitests.guihandles.MainMenuHandle;
 import guitests.guihandles.MainWindowHandle;
@@ -101,8 +102,8 @@ public abstract class AddressBookSystemTest {
         return mainWindowHandle.getCommandBox();
     }
 
-    public PersonListPanelHandle getPersonListPanel() {
-        return mainWindowHandle.getPersonListPanel();
+    public ClientListPanelHandle getClientListPanel() {
+        return mainWindowHandle.getClientListPanel();
     }
 
     public MainMenuHandle getMainMenu() {
@@ -149,7 +150,8 @@ public abstract class AddressBookSystemTest {
      */
     protected void showPersonsWithName(String keyword) {
         executeCommand(FindCommand.COMMAND_WORD + " " + keyword);
-        assertTrue(getModel().getFilteredPersonList().size() < getModel().getAddressBook().getPersonList().size());
+        System.out.println(getModel().getFilteredClientList().size());
+        assertTrue(getModel().getFilteredClientList().size() < getModel().getAddressBook().getPersonList().size());
     }
 
     /**
@@ -157,7 +159,7 @@ public abstract class AddressBookSystemTest {
      */
     protected void selectPerson(Index index) {
         executeCommand(SelectCommand.COMMAND_WORD + " " + index.getOneBased());
-        assertEquals(index.getZeroBased(), getPersonListPanel().getSelectedCardIndex());
+        assertEquals(index.getZeroBased(), getClientListPanel().getSelectedCardIndex());
     }
 
     /**
@@ -179,7 +181,7 @@ public abstract class AddressBookSystemTest {
         assertEquals(expectedResultMessage, getResultDisplay().getText());
         assertEquals(expectedModel, getModel());
         assertEquals(expectedModel.getAddressBook(), testApp.readStorageAddressBook());
-        assertListMatching(getPersonListPanel(), expectedModel.getFilteredPersonList());
+        assertListMatching(getClientListPanel(), expectedModel.getFilteredClientList());
     }
 
     /**
@@ -191,7 +193,7 @@ public abstract class AddressBookSystemTest {
         getBrowserPanel().rememberUrl();
         statusBarFooterHandle.rememberSaveLocation();
         statusBarFooterHandle.rememberSyncStatus();
-        getPersonListPanel().rememberSelectedPersonCard();
+        getClientListPanel().rememberSelectedClientCard();
     }
 
     /**
@@ -201,7 +203,7 @@ public abstract class AddressBookSystemTest {
      */
     protected void assertSelectedCardDeselected() {
         assertFalse(getBrowserPanel().isUrlChanged());
-        assertFalse(getPersonListPanel().isAnyCardSelected());
+        assertFalse(getClientListPanel().isAnyCardSelected());
     }
 
     /**
@@ -211,7 +213,7 @@ public abstract class AddressBookSystemTest {
      * @see PersonListPanelHandle#isSelectedPersonCardChanged()
      */
     protected void assertSelectedCardChanged(Index expectedSelectedCardIndex) {
-        String selectedCardName = getPersonListPanel().getHandleToSelectedCard().getName();
+        String selectedCardName = getClientListPanel().getHandleToSelectedCard().getName();
         URL expectedUrl;
         try {
             expectedUrl = new URL(BrowserPanel.SEARCH_PAGE_URL + selectedCardName.replaceAll(" ", "%20"));
@@ -220,7 +222,7 @@ public abstract class AddressBookSystemTest {
         }
         assertEquals(expectedUrl, getBrowserPanel().getLoadedUrl());
 
-        assertEquals(expectedSelectedCardIndex.getZeroBased(), getPersonListPanel().getSelectedCardIndex());
+        assertEquals(expectedSelectedCardIndex.getZeroBased(), getClientListPanel().getSelectedCardIndex());
     }
 
     /**
@@ -230,7 +232,7 @@ public abstract class AddressBookSystemTest {
      */
     protected void assertSelectedCardUnchanged() {
         assertFalse(getBrowserPanel().isUrlChanged());
-        assertFalse(getPersonListPanel().isSelectedPersonCardChanged());
+        assertFalse(getClientListPanel().isSelectedClientCardChanged());
     }
 
     /**
@@ -275,7 +277,7 @@ public abstract class AddressBookSystemTest {
         try {
             assertEquals("", getCommandBox().getInput());
             assertEquals("", getResultDisplay().getText());
-            assertListMatching(getPersonListPanel(), getModel().getFilteredPersonList());
+            assertListMatching(getClientListPanel(), getModel().getFilteredClientList());
             assertEquals(MainApp.class.getResource(FXML_FILE_FOLDER + DEFAULT_PAGE), getBrowserPanel().getLoadedUrl());
             assertEquals("./" + testApp.getStorageSaveLocation(), getStatusBarFooter().getSaveLocation());
             assertEquals(SYNC_STATUS_INITIAL, getStatusBarFooter().getSyncStatus());

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -15,6 +15,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;
@@ -39,6 +40,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 import seedu.address.testutil.TypicalPersons;
 import seedu.address.ui.BrowserPanel;
 import seedu.address.ui.CommandBox;
@@ -150,7 +152,9 @@ public abstract class AddressBookSystemTest {
      */
     protected void showPersonsWithName(String keyword) {
         executeCommand(FindCommand.COMMAND_WORD + " " + keyword);
-        assertTrue(getModel().getFilteredPersonList().size() <= getModel().getAddressBook().getPersonList().size());
+        assertTrue(getModel().getFilteredClientList().size()
+                <= getModel().getAddressBook().getPersonList().stream()
+                .filter(Person::isClient).collect(Collectors.toList()).size());
     }
 
     /**
@@ -175,7 +179,7 @@ public abstract class AddressBookSystemTest {
      * and the person list panel displays the persons in the model correctly.
      */
     protected void assertApplicationDisplaysExpected(String expectedCommandInput, String expectedResultMessage,
-            Model expectedModel) {
+                                                     Model expectedModel) {
         assertEquals(expectedCommandInput, getCommandBox().getInput());
         assertEquals(expectedResultMessage, getResultDisplay().getText());
         assertEquals(expectedModel, getModel());

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -150,8 +150,7 @@ public abstract class AddressBookSystemTest {
      */
     protected void showPersonsWithName(String keyword) {
         executeCommand(FindCommand.COMMAND_WORD + " " + keyword);
-        System.out.println(getModel().getFilteredClientList().size());
-        assertTrue(getModel().getFilteredClientList().size() < getModel().getAddressBook().getPersonList().size());
+        assertTrue(getModel().getFilteredPersonList().size() <= getModel().getAddressBook().getPersonList().size());
     }
 
     /**

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -62,14 +62,14 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
         /* Case: filtered person list, delete index within bounds of address book and person list -> deleted */
         showPersonsWithName(KEYWORD_MATCHING_MEIER);
         Index index = INDEX_FIRST_PERSON;
-        assertTrue(index.getZeroBased() < getModel().getFilteredPersonList().size());
+        assertTrue(index.getZeroBased() < getModel().getFilteredClientList().size());
         assertCommandSuccess(index);
 
         /* Case: filtered person list, delete index within bounds of address book but out of bounds of person list
          * -> rejected
          */
         showPersonsWithName(KEYWORD_MATCHING_MEIER);
-        int invalidIndex = getModel().getAddressBook().getPersonList().size();
+        int invalidIndex = getModel().getFilteredClientList().size();
         command = DeleteCommand.COMMAND_WORD + " " + invalidIndex;
         assertCommandFailure(command, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -69,7 +69,7 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
          * -> rejected
          */
         showPersonsWithName(KEYWORD_MATCHING_MEIER);
-        int invalidIndex = getModel().getFilteredClientList().size();
+        int invalidIndex = getModel().getAddressBook().getPersonList().size();
         command = DeleteCommand.COMMAND_WORD + " " + invalidIndex;
         assertCommandFailure(command, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -25,7 +25,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TECHNICIAN;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -105,9 +107,9 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         /* Case: filtered person list, edit index within bounds of address book and person list -> edited */
         showPersonsWithName(KEYWORD_MATCHING_MEIER);
         index = INDEX_FIRST_PERSON;
-        assertTrue(index.getZeroBased() < getModel().getFilteredPersonList().size());
+        assertTrue(index.getZeroBased() < getModel().getFilteredClientList().size());
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + NAME_DESC_BOB;
-        personToEdit = getModel().getFilteredPersonList().get(index.getZeroBased());
+        personToEdit = getModel().getFilteredClientList().get(index.getZeroBased());
         editedPerson = new PersonBuilder(personToEdit).withName(VALID_NAME_BOB).buildWithRoleClient();
         assertCommandSuccess(command, index, editedPerson);
 
@@ -210,12 +212,14 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
      * @see EditCommandSystemTest#assertCommandSuccess(String, Model, String, Index)
      */
     private void assertCommandSuccess(String command, Index toEdit, Person editedPerson,
-            Index expectedSelectedCardIndex) {
+                                      Index expectedSelectedCardIndex) {
         Model expectedModel = getModel();
         try {
             expectedModel.updatePerson(
-                    expectedModel.getFilteredPersonList().get(toEdit.getZeroBased()), editedPerson);
+                    expectedModel.getFilteredClientList().get(toEdit.getZeroBased()), editedPerson);
+            expectedModel.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
             expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            expectedModel.updateFilteredVetTechnicianList(PREDICATE_SHOW_ALL_TECHNICIAN);
         } catch (DuplicatePersonException | PersonNotFoundException e) {
             throw new IllegalArgumentException(
                     "editedPerson is a duplicate in expectedModel, or it isn't found in the model.");
@@ -249,9 +253,11 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
      * @see AddressBookSystemTest#assertSelectedCardChanged(Index)
      */
     private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage,
-            Index expectedSelectedCardIndex) {
+                                      Index expectedSelectedCardIndex) {
         executeCommand(command);
+        expectedModel.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
         expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        expectedModel.updateFilteredVetTechnicianList(PREDICATE_SHOW_ALL_TECHNICIAN);
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
         assertCommandBoxShowsDefaultStyle();
         if (expectedSelectedCardIndex != null) {

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -166,7 +166,7 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
      */
     private void assertCommandSuccess(String command, Model expectedModel) {
         String expectedResultMessage = String.format(
-                MESSAGE_PERSONS_LISTED_OVERVIEW, expectedModel.getFilteredPersonList().size());
+                MESSAGE_PERSONS_LISTED_OVERVIEW, expectedModel.getFilteredClientList().size());
 
         executeCommand(command);
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -135,7 +135,7 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         /* Case: find while a person is selected -> selected card deselected */
         showAllPersons();
         selectPerson(Index.fromOneBased(1));
-        assertFalse(getPersonListPanel().getHandleToSelectedCard().getName().equals(DANIEL.getName().fullName));
+        assertFalse(getClientListPanel().getHandleToSelectedCard().getName().equals(DANIEL.getName().fullName));
         command = FindCommand.COMMAND_WORD + " Daniel";
         ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);

--- a/src/test/java/systemtests/HelpCommandSystemTest.java
+++ b/src/test/java/systemtests/HelpCommandSystemTest.java
@@ -39,7 +39,7 @@ public class HelpCommandSystemTest extends AddressBookSystemTest {
         getMainMenu().openHelpWindowUsingAccelerator();
         assertHelpWindowOpen();
 
-        getPersonListPanel().click();
+        getClientListPanel().click();
         getMainMenu().openHelpWindowUsingAccelerator();
         assertHelpWindowOpen();
 
@@ -65,7 +65,7 @@ public class HelpCommandSystemTest extends AddressBookSystemTest {
         assertCommandBoxShowsDefaultStyle();
         assertNotEquals(HelpCommand.SHOWING_HELP_MESSAGE, getResultDisplay().getText());
         assertNotEquals(BrowserPanel.DEFAULT_PAGE, getBrowserPanel().getLoadedUrl());
-        assertListMatching(getPersonListPanel(), getModel().getFilteredPersonList());
+        assertListMatching(getClientListPanel(), getModel().getFilteredClientList());
 
         // assert that the status bar too is updated correctly while the help window is open
         // note: the select command tested above does not update the status bar

--- a/src/test/java/systemtests/ModelHelper.java
+++ b/src/test/java/systemtests/ModelHelper.java
@@ -1,39 +1,69 @@
 package systemtests;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
 import seedu.address.model.Model;
+import seedu.address.model.client.Client;
 import seedu.address.model.person.Person;
+import seedu.address.model.vettechnician.VetTechnician;
 
 /**
  * Contains helper methods to set up {@code Model} for testing.
  */
 public class ModelHelper {
-    private static final Predicate<Person> PREDICATE_MATCHING_NO_PERSONS = unused -> false;
+    private static final Predicate<Client> PREDICATE_MATCHING_NO_CLIENTS = unused -> false;
+    private static final Predicate<VetTechnician> PREDICATE_MATCHING_NO_TECHNICIANS = unused -> false;
 
     /**
      * Updates {@code model}'s filtered list to display only {@code toDisplay}.
      */
-    public static void setFilteredList(Model model, List<Person> toDisplay) {
-        Optional<Predicate<Person>> predicate =
-                toDisplay.stream().map(ModelHelper::getPredicateMatching).reduce(Predicate::or);
-        model.updateFilteredPersonList(predicate.orElse(PREDICATE_MATCHING_NO_PERSONS));
+    public static void setFilteredList(Model model,
+                                       List<Client> toDisplayClient, List<VetTechnician> toDisplayVetTechnician) {
+        Optional<Predicate<Client>> predicateClient = toDisplayClient.stream()
+                .map(ModelHelper::getPredicateMatchingClient).reduce(Predicate::or);
+        model.updateFilteredClientList(predicateClient.orElse(PREDICATE_MATCHING_NO_CLIENTS));
+        if (!toDisplayVetTechnician.isEmpty()) {
+            Optional<Predicate<VetTechnician>> predicateTechnician = toDisplayVetTechnician.stream()
+                    .map(ModelHelper::getPredicateMatchingTechnician).reduce(Predicate::or);
+            model.updateFilteredVetTechnicianList(predicateTechnician.orElse(PREDICATE_MATCHING_NO_TECHNICIANS));
+        }
     }
 
     /**
      * @see ModelHelper#setFilteredList(Model, List)
      */
     public static void setFilteredList(Model model, Person... toDisplay) {
-        setFilteredList(model, Arrays.asList(toDisplay));
+        List<Person> persons = Arrays.asList(toDisplay);
+        List<Client> clients = new ArrayList<>();
+        List<VetTechnician> technicians = new ArrayList<>();
+
+        for (int i = 0; i < persons.size(); i++) {
+            if (persons.get(i).isClient()) {
+                clients.add((Client) persons.get(i));
+            } else {
+                technicians.add((VetTechnician) persons.get(i));
+            }
+        }
+        persons = new ArrayList<>();
+        setFilteredList(model, clients, technicians);
     }
 
     /**
      * Returns a predicate that evaluates to true if this {@code Person} equals to {@code other}.
      */
-    private static Predicate<Person> getPredicateMatching(Person other) {
+    private static Predicate<Client> getPredicateMatchingClient(Person other) {
         return person -> person.equals(other);
     }
+
+    /**
+     * Returns a predicate that evaluates to true if this {@code Person} equals to {@code other}.
+     */
+    private static Predicate<VetTechnician> getPredicateMatchingTechnician(Person other) {
+        return person -> person.equals(other);
+    }
+
 }

--- a/src/test/java/systemtests/SampleDataTest.java
+++ b/src/test/java/systemtests/SampleDataTest.java
@@ -46,6 +46,6 @@ public class SampleDataTest extends AddressBookSystemTest {
     @Test
     public void addressBook_dataFileDoesNotExist_loadSampleData() {
         Person[] expectedList = SampleDataUtil.getSamplePersons();
-        assertListMatching(getPersonListPanel(), expectedList);
+        assertListMatching(getClientListPanel(), expectedList);
     }
 }

--- a/src/test/java/systemtests/SampleDataTest.java
+++ b/src/test/java/systemtests/SampleDataTest.java
@@ -26,6 +26,11 @@ public class SampleDataTest extends AddressBookSystemTest {
      * Returns a non-existent file location to force test app to load sample data.
      */
     @Override
+   
+    
+    
+    
+    
     protected String getDataFileLocation() {
         String filePath = TestUtil.getFilePathInSandboxFolder("SomeFileThatDoesNotExist1234567890.xml");
         deleteFileIfExists(filePath);

--- a/src/test/java/systemtests/SampleDataTest.java
+++ b/src/test/java/systemtests/SampleDataTest.java
@@ -26,11 +26,8 @@ public class SampleDataTest extends AddressBookSystemTest {
      * Returns a non-existent file location to force test app to load sample data.
      */
     @Override
-   
-    
-    
-    
-    
+
+
     protected String getDataFileLocation() {
         String filePath = TestUtil.getFilePathInSandboxFolder("SomeFileThatDoesNotExist1234567890.xml");
         deleteFileIfExists(filePath);

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -7,7 +7,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.SelectCommand.MESSAGE_SELECT_PERSON_SUCCESS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
-import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 
 import org.junit.Test;
 
@@ -29,7 +28,7 @@ public class SelectCommandSystemTest extends AddressBookSystemTest {
         assertCommandSuccess(command, INDEX_FIRST_PERSON);
 
         /* Case: select the last card in the person list -> selected */
-        Index personCount = Index.fromOneBased(getTypicalPersons().size());
+        Index personCount = Index.fromOneBased(getModel().getFilteredClientList().size());
         command = SelectCommand.COMMAND_WORD + " " + personCount.getOneBased();
         assertCommandSuccess(command, personCount);
 

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -115,7 +115,7 @@ public class SelectCommandSystemTest extends AddressBookSystemTest {
         Model expectedModel = getModel();
         String expectedResultMessage = String.format(
                 MESSAGE_SELECT_PERSON_SUCCESS, expectedSelectedCardIndex.getOneBased());
-        int preExecutionSelectedCardIndex = getPersonListPanel().getSelectedCardIndex();
+        int preExecutionSelectedCardIndex = getClientListPanel().getSelectedCardIndex();
 
         executeCommand(command);
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);


### PR DESCRIPTION
currentList stores the index of the list the vet is currently viewing, so that he/she can carry out the relevant commands on that list (like edit, delete etc.)

TODO:
- [x]  Bug to fix: Instances of mouseclick events to change tab BEFORE typing a 'list' command, does not update 'currentList'. However, after typing 'list' command to change list, changing tabs by mouseclick updates 'currentList'.
- [x]  Implement 'currentList' index in other client/vettech commands like 'delete', 'select' so that the command will change the correct list
- [x]  Fix relevant test cases

fully resolves #88 