### PR TITLE
Fix Reschdule, Schdule bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RescheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RescheduleCommand.java
@@ -76,7 +76,7 @@ public class RescheduleCommand extends UndoableCommand {
         } catch (DuplicateAppointmentException dpe) {
             throw new CommandException(MESSAGE_DUPLICATE_APPOINTMENT);
         } catch (AppointmentNotFoundException anfe) {
-            throw new AssertionError("The target appointment cannot be missing");
+            throw new CommandException(MESSAGE_DUPLICATE_APPOINTMENT);
         }
         model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENT);
 

--- a/src/main/java/seedu/address/model/appointment/Duration.java
+++ b/src/main/java/seedu/address/model/appointment/Duration.java
@@ -3,6 +3,8 @@ package seedu.address.model.appointment;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import seedu.address.model.appointment.exceptions.AppointmentCloseToNextException;
+
 //@@author Godxin-functional
 /**
  * Represents an Appointment's duration in the application.
@@ -33,9 +35,11 @@ public class Duration {
         this.duration = duration;
     }
 
-    public Duration(int duration) {
+    public Duration(int duration) throws AppointmentCloseToNextException {
         String durationString = "" + duration;
-        checkArgument(isValidDuration(durationString), MESSAGE_DURATION_CONSTRAINTS);
+        if (!isValidDuration(durationString)) {
+            throw new AppointmentCloseToNextException("Appointment cannot be scheduled at this duration");
+        }
         this.duration = durationString;
     }
 


### PR DESCRIPTION
These errors were not handled properly to return a result message.
1) schdule appointment that have no suggested duration.  e.g. 0-15 min before an appointment
2) reschdule appointment to an appointment that already exists 